### PR TITLE
Implement QAPRO sample prototype

### DIFF
--- a/qapro/README.md
+++ b/qapro/README.md
@@ -1,0 +1,19 @@
+# QAPRO Sample Implementation
+
+This directory contains a lightweight prototype of the QAPRO accreditation workflow. It is not production-ready but demonstrates the core flow:
+
+1. Provider registration
+2. Task creation and completion
+3. Document uploads
+4. Simple internal audit that checks if tasks are complete
+
+## Running
+
+Install dependencies and run the Flask development server:
+
+```bash
+pip install flask flask_sqlalchemy
+python qapro/app.py
+```
+
+The app will create an SQLite database (`qapro.db`) and a folder `uploads/` for uploaded documents.

--- a/qapro/app.py
+++ b/qapro/app.py
@@ -1,0 +1,98 @@
+from flask import Flask, render_template, request, redirect, url_for, flash
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'changeme'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///qapro.db'
+app.config['UPLOAD_FOLDER'] = 'uploads'
+
+db = SQLAlchemy(app)
+
+if not os.path.exists('uploads'):
+    os.makedirs('uploads')
+
+class Provider(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(120), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text)
+    provider_id = db.Column(db.Integer, db.ForeignKey('provider.id'))
+    completed = db.Column(db.Boolean, default=False)
+
+class Document(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(200))
+    provider_id = db.Column(db.Integer, db.ForeignKey('provider.id'))
+
+@app.route('/')
+def index():
+    providers = Provider.query.all()
+    return render_template('index.html', providers=providers)
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        name = request.form['name']
+        email = request.form['email']
+        provider = Provider(name=name, email=email)
+        db.session.add(provider)
+        db.session.commit()
+        flash('Provider registered!')
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+@app.route('/provider/<int:provider_id>')
+def provider_detail(provider_id):
+    provider = Provider.query.get_or_404(provider_id)
+    tasks = Task.query.filter_by(provider_id=provider.id).all()
+    docs = Document.query.filter_by(provider_id=provider.id).all()
+    return render_template('provider_detail.html', provider=provider, tasks=tasks, docs=docs)
+
+@app.route('/provider/<int:provider_id>/add_task', methods=['POST'])
+def add_task(provider_id):
+    title = request.form['title']
+    desc = request.form.get('description', '')
+    task = Task(title=title, description=desc, provider_id=provider_id)
+    db.session.add(task)
+    db.session.commit()
+    return redirect(url_for('provider_detail', provider_id=provider_id))
+
+@app.route('/task/<int:task_id>/complete')
+def complete_task(task_id):
+    task = Task.query.get_or_404(task_id)
+    task.completed = True
+    db.session.commit()
+    return redirect(url_for('provider_detail', provider_id=task.provider_id))
+
+@app.route('/provider/<int:provider_id>/upload', methods=['POST'])
+def upload(provider_id):
+    file = request.files['document']
+    if file:
+        filepath = os.path.join(app.config['UPLOAD_FOLDER'], file.filename)
+        file.save(filepath)
+        doc = Document(filename=file.filename, provider_id=provider_id)
+        db.session.add(doc)
+        db.session.commit()
+    return redirect(url_for('provider_detail', provider_id=provider_id))
+
+@app.route('/audit/<int:provider_id>')
+def audit(provider_id):
+    provider = Provider.query.get_or_404(provider_id)
+    tasks = Task.query.filter_by(provider_id=provider.id).all()
+    if all(t.completed for t in tasks):
+        flash('Audit passed. QAPRO certificate issued.')
+    else:
+        flash('Audit failed. Complete all tasks.')
+    return redirect(url_for('provider_detail', provider_id=provider.id))
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/qapro/templates/index.html
+++ b/qapro/templates/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>QAPRO Providers</title>
+<h1>Providers</h1>
+<a href="{{ url_for('register') }}">Register Provider</a>
+<ul>
+{% for p in providers %}
+    <li><a href="{{ url_for('provider_detail', provider_id=p.id) }}">{{ p.name }}</a></li>
+{% else %}
+    <li>No providers yet.</li>
+{% endfor %}
+</ul>

--- a/qapro/templates/provider_detail.html
+++ b/qapro/templates/provider_detail.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>Provider Detail</title>
+<h1>{{ provider.name }}</h1>
+<p>{{ provider.email }}</p>
+<h2>Tasks</h2>
+<form method="post" action="{{ url_for('add_task', provider_id=provider.id) }}">
+    <label>Title <input name="title"></label>
+    <input type="submit" value="Add Task">
+</form>
+<ul>
+{% for t in tasks %}
+    <li>
+        {{ t.title }} {% if not t.completed %}<a href="{{ url_for('complete_task', task_id=t.id) }}">complete</a>{% else %}✅{% endif %}
+    </li>
+{% else %}
+    <li>No tasks yet.</li>
+{% endfor %}
+</ul>
+<h2>Documents</h2>
+<form method="post" action="{{ url_for('upload', provider_id=provider.id) }}" enctype="multipart/form-data">
+    <input type="file" name="document">
+    <input type="submit" value="Upload">
+</form>
+<ul>
+{% for d in docs %}
+    <li>{{ d.filename }}</li>
+{% else %}
+    <li>No documents.</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('audit', provider_id=provider.id) }}">Run Audit</a>
+<p>{% with messages = get_flashed_messages() %}{% if messages %}{% for m in messages %}<div>{{ m }}</div>{% endfor %}{% endif %}{% endwith %}</p>
+<a href="{{ url_for('index') }}">Back to providers</a>

--- a/qapro/templates/register.html
+++ b/qapro/templates/register.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Register Provider</title>
+<h1>Register Provider</h1>
+<form method="post">
+    <label>Name <input name="name"></label><br>
+    <label>Email <input name="email"></label><br>
+    <input type="submit" value="Register">
+</form>


### PR DESCRIPTION
## Summary
- create a `qapro` folder with a simple Flask app
- include templates for provider registration, tasks and documents
- demonstrate basic internal audit flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858345c9b2c832197f16aba4344047e